### PR TITLE
V8 optimizations

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,10 +19,11 @@ if ( typeof WeakMap === 'undefined' || typeof Map === 'undefined' ) {
     // Browser globals (root is window)
     root.returnExports = factory();
   }
-}(this, function () {
+})(this, function () {
 
   var _idMap = new WeakMap();
   var _id = { id: 0 };
+
   // the last two arguments help with testing
   return function memoize(fn, cache, idMap, id) {
     if ( !cache ) {
@@ -35,41 +36,44 @@ if ( typeof WeakMap === 'undefined' || typeof Map === 'undefined' ) {
       id = _id;
     }
 
-    return function() {
-      var aKey = [];
-      for ( var i = 0; i < arguments.length; i++ ) {
-        var argType = typeof arguments[i];
-
-        // if the argument is not a primitive, get a unique (memoized?) id for it
-        if (
-          // typeof null is "object", although we'll consider it as a primitive
-          arguments[i] !== null &&
-          ( argType === 'object' || argType === 'function' || argType === 'symbol' )
-        ) {
-          if ( !idMap.has(arguments[i]) ) {
-            idMap.set(arguments[i], id.id++);
-          }
-          aKey.push( idMap.get(arguments[i]) );
-
-        // otherwise, add the argument and its type to the aKey
-        } else {
-          aKey.push( arguments[i] == null ?
-            '' + arguments[i] :
-            argType + '(' + arguments[i] + ')'
-          );
-        }
-      }
-
-      var sKey = aKey.join('_///_');
-
-      if ( !cache.has(sKey) ) {
-        var result = fn.apply(this, arguments);
-        cache.set( sKey, result );
-        return result;
-      }
-
-      return cache.get( sKey );
+    return function(/* ...args */) {
+      return memoizedCall(fn, cache, idMap, id, arguments);
     };
   };
 
-}));
+  function memoizedCall (fn, cache, idMap, id, args) {
+    var aKey = [];
+    for ( var i = 0; i < args.length; i++ ) {
+      var argType = typeof args[i];
+
+      // if the argument is not a primitive, get a unique (memoized?) id for it
+      if (
+        // typeof null is "object", although we'll consider it as a primitive
+        args[i] !== null &&
+        ( argType === 'object' || argType === 'function' || argType === 'symbol' )
+      ) {
+        if ( !idMap.has(args[i]) ) {
+          idMap.set(args[i], id.id++);
+        }
+        aKey.push( idMap.get(args[i]) );
+
+      // otherwise, add the argument and its type to the aKey
+      } else {
+        aKey.push( args[i] == null ?
+          '' + args[i] :
+          argType + '(' + args[i] + ')'
+        );
+      }
+    }
+
+    var sKey = aKey.join('_///_');
+
+    if ( !cache.has(sKey) ) {
+      var result = fn.apply(this, args);
+      cache.set( sKey, result );
+      return result;
+    }
+
+    return cache.get( sKey );
+  }
+})

--- a/index.js
+++ b/index.js
@@ -24,8 +24,13 @@ if ( typeof WeakMap === 'undefined' || typeof Map === 'undefined' ) {
   var _idMap = new WeakMap();
   var _id = { id: 0 };
 
+  // exported for tests
+  memoize.__call__ = memoizedCall;
+
+  return memoize;
+
   // the last two arguments help with testing
-  return function memoize(fn, cache, idMap, id) {
+  function memoize(fn, cache, idMap, id) {
     if ( !cache ) {
       cache = new Map();
     }
@@ -39,7 +44,7 @@ if ( typeof WeakMap === 'undefined' || typeof Map === 'undefined' ) {
     return function(/* ...args */) {
       return memoizedCall(fn, cache, idMap, id, arguments);
     };
-  };
+  }
 
   function memoizedCall (fn, cache, idMap, id, args) {
     var aKey = [];

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "devDependencies": {
     "chai": "^3.5.0",
+    "chalk": "^1.1.3",
     "eslint": "^2.9.0",
     "eslint-plugin-mocha": "^2.2.0",
     "mocha": "^2.4.5",

--- a/test-is-optimized.js
+++ b/test-is-optimized.js
@@ -1,0 +1,64 @@
+// Usage: node --allow-natives-syntax test-is-optimized.js
+
+const memoize = require('./');
+const chalk = require('chalk');
+
+let finalExitCode = 0;
+
+function foo () {
+  return 42;
+}
+
+function unoptimizable () {
+  try {
+    return 33;
+  } catch (e) {
+    return e;
+  }
+}
+
+function memoizedCall () {
+  return memoize.__call__(foo, new Map, new WeakMap, {id: 0}, []);
+}
+
+
+
+check('memoize', function () { memoize(function () {}) }, true);
+check('memoized.__call__', memoizedCall, true);
+check('add', foo, true);
+check('unoptimizable', unoptimizable, false);
+check('memoized(add)', memoize(foo), true);
+
+process.exit(finalExitCode);
+
+
+
+function printStatus(fn) {
+  switch(%GetOptimizationStatus(fn)) {
+    case 1: return chalk.green("Function is optimized"); break;
+    case 2: return chalk.red("Function is not optimized"); break;
+    case 3: return chalk.green("Function is always optimized"); break;
+    case 4: return chalk.red("Function is never optimized"); break;
+    case 6: return chalk.cyan("Function is maybe deoptimized"); break;
+    case 7: return chalk.green("Function is optimized by TurboFan"); break;
+    default: return chalk.cyan("Unknown optimization status"); break;
+  }
+}
+
+function check (label, fn, expectOptimized) {
+  // Run function once
+  fn();
+
+  // Tag function for optimization
+  %OptimizeFunctionOnNextCall(fn);
+
+  // 2 calls are needed to go from uninitialized -> pre-monomorphic -> monomorphic
+  fn();
+
+  // Check/verify it (of not have code that cant be optimised)
+  const status = printStatus(fn);
+  if (typeof expectOptimized === 'boolean' && expectOptimized !== !!status.match(/is (always )?optimized/)) {
+    finalExitCode = 1;
+  }
+  console.log(chalk.bold(label) + ': ' + status);
+}

--- a/test.js
+++ b/test.js
@@ -39,11 +39,12 @@ describe('memoize', function() {
 
   it('should memoize a result when called with 1 primitive arg', function(done) {
     var nbExecs = 0;
-    var fn = function() {
+    var arg1 = 12;
+    var fn = function(arg) {
+      expect(arg).to.equal(arg1);
       return ++nbExecs;
     };
     var memoizedFn = memoize(fn, cache, idMap, id);
-    var arg1 = 12;
 
     // first execution with empty cache
     expect(memoizedFn(arg1)).to.equal(1);
@@ -64,11 +65,12 @@ describe('memoize', function() {
 
   it('should memoize a result when called with 1 non-primitive arg', function(done) {
     var nbExecs = 0;
-    var fn = function() {
+    var arg1 = {};
+    var fn = function(arg) {
+      expect(arg).to.equal(arg1);
       return ++nbExecs;
     };
     var memoizedFn = memoize(fn, cache, idMap, id);
-    var arg1 = {};
 
     // first execution with empty cache
     expect(memoizedFn(arg1)).to.equal(1);
@@ -89,10 +91,6 @@ describe('memoize', function() {
 
   it('should memoize a result when called with mixed primitive and non-primitive args', function(done) {
     var nbExecs = 0;
-    var fn = function() {
-      return ++nbExecs;
-    };
-    var memoizedFn = memoize(fn, cache, idMap, id);
     var arg1 = {a:'b'};
     var arg2 = 'string';
     var arg3 = [1,2];
@@ -101,6 +99,18 @@ describe('memoize', function() {
     var arg6 = null;
     var arg7 = false;
     var arg8 = undefined;
+    var fn = function(a, b, c, d, e, f, g, h) {
+      expect(a).to.equal(arg1);
+      expect(b).to.equal(arg2);
+      expect(c).to.equal(arg3);
+      expect(d).to.equal(arg4);
+      expect(e).to.equal(arg5);
+      expect(f).to.equal(arg6);
+      expect(g).to.equal(arg7);
+      expect(h).to.equal(arg8);
+      return ++nbExecs;
+    };
+    var memoizedFn = memoize(fn, cache, idMap, id);
 
     // first execution with empty cache
     expect(memoizedFn(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)).to.equal(1);
@@ -117,6 +127,20 @@ describe('memoize', function() {
     expect(cache.get('0_///_string(string)_///_1_///_2_///_number(12)_///_null_///_boolean(false)_///_undefined'))
       .to.equal(1);
     expect(idMap.size).to.equal(3);
+
+    done();
+  });
+
+  it('should strip extra arguments unless unoptimized', function(done) {
+    var arg1 = {a:'b'};
+    var fn = function() {
+      expect(arguments[0]).to.equal(arg1);
+    };
+    var memoizedFn = memoize(fn, cache, idMap, id);
+    var memoizedFnUnoptimized = memoize.unoptimized(fn, cache, idMap, id);
+
+    expect(function () { memoizedFn(arg1) }).to.throw('AssertionError');
+    expect(function () { memoizedFnUnoptimized(arg1); }).to.not.throw();
 
     done();
   });


### PR DESCRIPTION
- `memoize` now returns a function with same arity as original one, extra arguments stripped, but the returned function is now optimized by V8
- adds `memoize.unoptimized` which returns a function accepting any number of arguments
- tests updated accordingly
- README **not** updated
