### PR TITLE
Fix README indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,27 +71,40 @@ NB: When in doubt, don't use an optional cache.
 The following instructions will help choose optimal cache store for a given function. Before you proceed, make sure you know the definition of the following terms:
 - *primitive*: Any `number`, `string`, `boolean`, `undefined` or `null` value is considered primitive.
 - *non-primitive*: An `object`, `array` or `function` value is non-primitive.
-- *named arguments*: here is a function that doesn't accept named arguments:
-    `drawRect(20, 50, 100, 150, '#000');`
-  and the same function, accepting named arguments:
-    `drawRect({x: 20, y: 50, width: 100, height: 150, color: '#000'});`
-  which is expected to have the exact same result as:
-    `drawRect({color: '#000', width: 100, height: 150, x: 20, y: 50});`
+- *named arguments*:
+
+    Here is a function that doesn't accept named arguments:
+    
+    ```js
+    drawRect(20, 50, 100, 150, '#000');
+    ```
+    
+    and the same function, accepting named arguments:
+    
+    ```js
+    drawRect({x: 20, y: 50, width: 100, height: 150, color: '#000'});
+    ```
+    
+    which is expected to have the exact same result as:
+    
+    ```js
+    drawRect({color: '#000', width: 100, height: 150, x: 20, y: 50});
+    ```
 
 1. The function accepts a single argument (**not named argument**, see below)
-  1. The function accepts a single non-primitive argument.
-     → use a native WeakMap.
-  2. The function accepts a single primitive argument.
-     → use the [LRUMap](https://github.com/memoize-immutable/LRUMap) (or a native Map if its size isn't a problem).
+    1. The function accepts a single non-primitive argument.
+        → use a native [WeakMap](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap).
+    2. The function accepts a single primitive argument.
+        → use the [LRUMap](https://github.com/memoize-immutable/LRUMap) (or a native [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) if its size isn't a problem).
 2. The function accepts multiple arguments, but the number of arguments never changes
-  1. The function accepts primitive arguments, **always mixed with at least one non-primitive argument**
-     → use the [MixedTupleMap](https://github.com/memoize-immutable/MixedTupleMap).
-  2. The function only accepts non-primitive arguments.
-     → use the [WeakTupleMap](https://github.com/memoize-immutable/WeakTupleMap).
+    1. The function accepts primitive arguments, **always mixed with at least one non-primitive argument**
+        → use the [MixedTupleMap](https://github.com/memoize-immutable/MixedTupleMap).
+    2. The function only accepts non-primitive arguments.
+        → use the [WeakTupleMap](https://github.com/memoize-immutable/WeakTupleMap).
 3. The function accepts a single object of named arguments
-  → use the [NamedTupleMap](https://github.com/memoize-immutable/NamedTupleMap).
+    → use the [NamedTupleMap](https://github.com/memoize-immutable/NamedTupleMap).
 4. **In any other case**
-   → use the default [TupleMap](https://github.com/memoize-immutable/TupleMap).
+    → use the default [TupleMap](https://github.com/memoize-immutable/TupleMap).
 
 ## License
 


### PR DESCRIPTION
GitHub markdown is really picky about spacing and indentation. It requires 4-space indentation for lists, otherwise it ignores the indentation entirely 🙄 I was really confused until I saw the raw text and realized there were supposed to be sub-sections.

Also added a couple links to native Map documentation.